### PR TITLE
Update: Update magnus to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ exclude = [".gitignore", ".github"]
 
 [dependencies]
 serde = "1.0"
-magnus = "0.6.2"
+magnus = "0.7.1"
 tap = "1.0"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
-magnus = { version = "0.6.2", features = ["embed"] }
+magnus = { version = "0.7.1", features = ["embed"] }


### PR DESCRIPTION
This PR updates magnus to 0.7.1.
In magnus 0.7, some apis used by this crate are marked as old-api, so (maybe) apis should be changed to receive `&Ruby`.