### PR TITLE
Adds ruby 3.3 to mix of tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - "3.0"
           - "3.1"
           - "3.2"
+          - "3.3"
 
     steps:
       - name: Check out code

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -400,5 +400,5 @@ where
     Input: Serialize + ?Sized,
     Output: TryConvert,
 {
-    TryConvert::try_convert(input.serialize(Serializer)?).map_err(Into::into)
+    TryConvert::try_convert(input.serialize(Serializer)?)
 }


### PR DESCRIPTION
Adds in ruby 3.3 now that others are EOL. This also corrects a clippy warning which is blocking release.