### PR TITLE
Prefer `visit_string` to `visit_str` when we already have an owned `String`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rustup-toolchain:
           - stable
-          - "1.65"
+          - "1.71"
         ruby-version:
           - "3.0"
           - "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_magnus"
-version = "0.10.0"
+version = "0.11.0"
 description = "Serde integration for Magnus"
 edition = "2018"
 rust-version = "1.71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "serde_magnus"
 version = "0.10.0"
 description = "Serde integration for Magnus"
 edition = "2018"
-rust-version = "1.65"
+rust-version = "1.71"
 authors = [
     "Joe Wilm <joe@jwilm.com>",
     "George Claghorn <georgeclaghorn@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ assert_eq!(
 
 ## Requirements
 
-`serde_magnus` requires Rust 1.65+ and Ruby 3.0+.
+`serde_magnus` requires Rust 1.71+ and Ruby 3.0+.
 
 ## License
 

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -55,7 +55,7 @@ impl<'r, 'i> serde::Deserializer<'i> for Deserializer<'r> {
         }
 
         if let Some(symbol) = Symbol::from_value(self.value) {
-            return visitor.visit_str(symbol.name()?.to_string().as_str());
+            return visitor.visit_string(symbol.name()?.to_string());
         }
 
         if let Some(array) = RArray::from_value(self.value) {

--- a/src/de/deserializer.rs
+++ b/src/de/deserializer.rs
@@ -51,7 +51,7 @@ impl<'r, 'i> serde::Deserializer<'i> for Deserializer<'r> {
         }
 
         if let Some(string) = RString::from_value(self.value) {
-            return visitor.visit_str(string.to_string()?.as_str());
+            return visitor.visit_string(string.to_string()?);
         }
 
         if let Some(symbol) = Symbol::from_value(self.value) {


### PR DESCRIPTION
See commits for details.

I benchmarked this on my machine (an M1 Pro) by deserializing some String-heavy structs and for me this change results in a ~10% speed-up.

I had to bump the MSRV to get CI passing.